### PR TITLE
Fix the error where self.iri is set to None when calling super().__init__ when the superclass is Klass

### DIFF
--- a/client/model/agent.py
+++ b/client/model/agent.py
@@ -1,7 +1,7 @@
 from typing import Optional, List
 from typing import Literal as Lit
 
-from client.model.klass import Klass
+from .klass import Klass
 
 from rdflib import Graph, URIRef, Literal
 from rdflib.namespace import RDF, RDFS, OWL, SDO

--- a/client/model/feature_of_interest.py
+++ b/client/model/feature_of_interest.py
@@ -4,9 +4,10 @@ from rdflib import Graph, URIRef, Literal
 from rdflib.namespace import RDF, RDFS, SOSA, OWL, VOID
 
 from client.model._TERN import TERN
-from client.model.concept import Concept
-from client.model.klass import Klass
-from client.model.tern_dataset import Dataset
+import client.model as model
+from .concept import Concept
+from .klass import Klass
+from .tern_dataset import Dataset
 
 
 class FeatureOfInterest(Klass):
@@ -15,7 +16,7 @@ class FeatureOfInterest(Klass):
             feature_type: Concept,
             in_dataset: Dataset,
             iri: Optional[str] = None,
-            has_sample: Optional["Sample"] = None,
+            has_sample: Optional["model.Sample"] = None,
     ):
         assert isinstance(
             feature_type.__class__, Concept.__class__
@@ -29,7 +30,7 @@ class FeatureOfInterest(Klass):
         # importing seems to trigger a circular ImportError
 
         if has_sample is not None:
-            assert isinstance(Sample.__class__, has_sample.__class__), \
+            assert isinstance(model.Sample.__class__, has_sample.__class__), \
                 f"The object supplied for the property has_sample must be of type Sample "
 
         """Receive and use or make an IRI"""

--- a/client/model/klass.py
+++ b/client/model/klass.py
@@ -8,16 +8,16 @@ from client.model._TERN import TERN
 
 
 class Klass:
-    iri = None
+    iri: URIRef
 
     def __init__(self, iri: Optional[str] = None):
         """Receive and use or make an IRI"""
         if iri is None:
-            self.id = self.make_uuid()
-            iri = URIRef(f"http://example.com/{self.id}")
+            self.uuid = self.make_uuid()
+            iri = URIRef(f"http://example.com/{self.uuid}")
 
         self.iri = URIRef(iri)
-        self.label = f"Class with ID {self.id if hasattr(self, 'id') else self.iri.split('/')[-1]}"
+        self.label = f"Class with ID {self.uuid if hasattr(self, 'uuid') else self.iri.split('/')[-1]}"
 
     def make_uuid(self):
         return uuid4()

--- a/client/model/sample.py
+++ b/client/model/sample.py
@@ -4,20 +4,21 @@ from rdflib import Graph, URIRef, Literal
 from rdflib.namespace import OWL, RDF, RDFS, SOSA, VOID
 
 from client.model._TERN import TERN
-from client.model.concept import Concept
-from client.model.feature_of_interest import FeatureOfInterest
-from client.model.klass import Klass
-from client.model.tern_dataset import Dataset
-from client.model.site import Site
+import client.model as model
+from .concept import Concept
+from .klass import Klass
+from .tern_dataset import Dataset
+from .site import Site
+
 
 
 class Sample(Klass):
     def __init__(
         self,
-        is_sample_of: List[Union[FeatureOfInterest, Site]],
+        is_sample_of: List[Union["model.FeatureOfInterest", Site]],
         feature_type: Concept,
         in_dataset: Dataset,
-        is_result_of: Union["Sampling", None],
+        is_result_of: Union["model.Sampling", None],
         iri: Optional[str] = None,
     ):
         assert (
@@ -25,11 +26,11 @@ class Sample(Klass):
         ), "You must supply a minimum of 1 FeatureOfInterest objects for the property is_sample_of"
 
         assert all(
-            isinstance(el.__class__, FeatureOfInterest.__class__) for el in is_sample_of
+            isinstance(el.__class__, model.FeatureOfInterest.__class__) for el in is_sample_of
         ), "Every object supplied in the property is_sample_of must be of type FeatureOfInterest"
 
-        # assert type(is_result_of) == Sampling, \
-        #     "The object supplied for the property is_result_of must be of type Sampling"
+        assert isinstance(is_result_of.__class__, model.Sampling.__class__), \
+            "The object supplied for the property is_result_of must be of type Sampling"
 
         assert isinstance(
             feature_type.__class__, Concept.__class__

--- a/client/model/sampling.py
+++ b/client/model/sampling.py
@@ -6,12 +6,11 @@ from rdflib.namespace import RDF, RDFS, SOSA, OWL, XSD
 GEO = Namespace("http://www.opengis.net/ont/geosparql#")
 
 from client.model._TERN import TERN
-from client.model.feature_of_interest import FeatureOfInterest
-from client.model.klass import Klass
-from client.model.sample import Sample
-from client.model.site import Site
+import client.model as model
+from .feature_of_interest import FeatureOfInterest
+from .klass import Klass
 from shapely.geometry import Point
-from client.model.site_visit import SiteVisit
+from .site_visit import SiteVisit
 
 
 class Sampling(Klass):
@@ -20,7 +19,7 @@ class Sampling(Klass):
         has_feature_of_interest: FeatureOfInterest,
         result_date_time: Literal,
         used_procedure: URIRef,
-        has_result: List[Sample] = [],
+        has_result: List["model.Sample"] = [],
         iri: Optional[str] = None,
         geometry: Optional[Point] = None,
         has_site_visit: Optional[SiteVisit] = None
@@ -48,7 +47,7 @@ class Sampling(Klass):
 
         if len(has_result) > 0:
             assert all(
-                isinstance(el.__class__, Sample.__class__) for el in has_result
+                isinstance(el.__class__, model.Sample.__class__) for el in has_result
             ), "Every value supplied for has_result must be of type Sample"
 
         if geometry is not None:
@@ -64,9 +63,7 @@ class Sampling(Klass):
             self.id = self.make_uuid()
             iri = URIRef(f"http://example.com/sampling/{self.id}")
 
-        self.iri = URIRef(iri)
-
-        super().__init__(iri)
+        super().__init__(iri)  # this sets self.iri = iri
 
         self.label = f"Sampling with ID {self.id if hasattr(self, 'id') else self.iri.split('/')[-1]}"
 

--- a/client/model/tern_dataset.py
+++ b/client/model/tern_dataset.py
@@ -4,9 +4,9 @@ from rdflib import Graph, URIRef, Literal
 from rdflib.namespace import RDF, RDFS, OWL, DCTERMS, XSD
 
 from client.model._TERN import TERN
-from client.model.klass import Klass
-from client.model.agent import Agent
-from client.model.concept import Concept
+from .klass import Klass
+from .agent import Agent
+from .concept import Concept
 import re
 
 
@@ -65,20 +65,22 @@ class Dataset(Klass):
                 "If you provide a value for the issued parameter, it must be of type string"
             assert date_pattern.match(issued), "The value for issued you provided is not in the YYYY-MM-DD format"
 
+        self.uuid = self.make_uuid()
+
         """Receive and use or make an IRI"""
         if iri is None:
-            self.id = self.make_uuid()
-            iri = URIRef(f"http://example.com/dataset/{self.id}")
+            iri = URIRef(f"http://example.com/dataset/{self.uuid}")
+            self.use_identifier = str(self.uuid)
+        else:
+            self.use_identifier = iri.split('/')[-1]
 
-        self.iri = URIRef(iri)
+        super().__init__(iri)  # this sets self.iri = iri
 
-        super().__init__(iri)
-        
         if title is not None:
             self.title = title
             self.label = title
         else:
-            self.title = f"RDF Dataset with ID {self.id if hasattr(self, 'id') else self.iri.split('/')[-1]}"
+            self.title = f"RDF Dataset with ID {self.use_identifier}"
             self.label = self.title
 
         if description is not None:

--- a/client/synthesizer_tern.py
+++ b/client/synthesizer_tern.py
@@ -50,15 +50,15 @@ SCIENTIFIC_NAME_IDS = [
 
 class TernSynthesizer:
     datasets: List[Dataset]
-    fois = List[FeatureOfInterest]
-    sites = List[Site]
-    samplings = List[Sampling]
-    samples = List[Sample]
-    observations = List[Observation]
-    taxa = List[Taxon]
+    fois: List[FeatureOfInterest]
+    sites: List[Site]
+    samplings: List[Sampling]
+    samples: List[Sample]
+    observations: List[Observation]
+    taxa: List[Taxon]
     coordinate_bounding_box: Polygon
-    coordinate_points = List[Point]
-    site_visit = List[SiteVisit]
+    coordinate_points: List[Point]
+    site_visit: List[SiteVisit]
 
     def __init__(
             self, n: int,


### PR DESCRIPTION
This PR has three fixes:
1) Fix the error where self.iri is set to None when calling super().__init__ when the superclass is Klass
2) Also add some relative imports and some named imports to fix the circular imports issue.
3) Fix the typing declarations on tern_synthesizer. (use colons, not assignments)